### PR TITLE
fix python packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 
 [build-system]
 requires = ["setuptools>=63.2.0", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name =  "netbox-healthcheck-plugin"
@@ -25,7 +26,7 @@ classifiers=[
 
 requires-python = ">=3.8.1"
 # dynamic = ["version"]
-version = "0.1.0"
+version = "0.1.1"
 
 dependencies = [
     'django-health-check >= 3,<4'
@@ -54,7 +55,10 @@ Source = "https://github.com/netbox-community/netbox-healthcheck-plugin"
 Tracker = "https://github.com/netbox-community/netbox-healthcheck-plugin/issues"
 
 [tool.setuptools]
-py-modules = ["netbox_healthcheck_plugin",]
+packages = ["netbox_healthcheck_plugin"]
+
+[tool.setuptools.package-data]
+netbox_healthcheck_plugin = ["templates/**"]
 
 [tool.bandit]
 exclude_dirs = ["build","dist","tests","scripts","docs"]


### PR DESCRIPTION
The python packaging seems to be broken as reported in #7 where the actual python module is missing from the distribution when isntalling from PyPI or directly from source.

This updates the `[tools.setuptools]` to use  `package` instead of `py-modules`.

> Note: Also concider using hatchling or flit (both are supported by the Python Foundation) as alternatives to setuptools which is concidered a bit legacy at this point.  I'd be happy to change to either one, both are light weight and support full PEP support.

## Before:
```
$ python3 -m build
<--output removed>
$ tar tfv dist/netbox-healthcheck-plugin-0.1.0.tar.gz
x netbox-healthcheck-plugin-0.1.0/
x netbox-healthcheck-plugin-0.1.0/CONTRIBUTING.md
x netbox-healthcheck-plugin-0.1.0/LICENSE
x netbox-healthcheck-plugin-0.1.0/MANIFEST.in
x netbox-healthcheck-plugin-0.1.0/PKG-INFO
x netbox-healthcheck-plugin-0.1.0/README.md
x netbox-healthcheck-plugin-0.1.0/netbox_healthcheck_plugin.egg-info/
x netbox-healthcheck-plugin-0.1.0/netbox_healthcheck_plugin.egg-info/PKG-INFO
x netbox-healthcheck-plugin-0.1.0/netbox_healthcheck_plugin.egg-info/SOURCES.txt
x netbox-healthcheck-plugin-0.1.0/netbox_healthcheck_plugin.egg-info/dependency_links.txt
x netbox-healthcheck-plugin-0.1.0/netbox_healthcheck_plugin.egg-info/requires.txt
x netbox-healthcheck-plugin-0.1.0/netbox_healthcheck_plugin.egg-info/top_level.txt
x netbox-healthcheck-plugin-0.1.0/pyproject.toml
x netbox-healthcheck-plugin-0.1.0/setup.cfg
x netbox-healthcheck-plugin-0.1.0/tests/
x netbox-healthcheck-plugin-0.1.0/tests/__init__.py
x netbox-healthcheck-plugin-0.1.0/tests/test_netbox_healthcheck_plugin.py
```

## After:
```
$ tar tfv dist/netbox-healthcheck-plugin-0.1.1.tar.gz
x netbox-healthcheck-plugin-0.1.1/
x netbox-healthcheck-plugin-0.1.1/CONTRIBUTING.md
x netbox-healthcheck-plugin-0.1.1/LICENSE
x netbox-healthcheck-plugin-0.1.1/MANIFEST.in
x netbox-healthcheck-plugin-0.1.1/PKG-INFO
x netbox-healthcheck-plugin-0.1.1/README.md
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin/
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin/__init__.py
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin/navigation.py
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin/urls.py
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin/views.py
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin.egg-info/
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin.egg-info/PKG-INFO
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin.egg-info/SOURCES.txt
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin.egg-info/dependency_links.txt
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin.egg-info/requires.txt
x netbox-healthcheck-plugin-0.1.1/netbox_healthcheck_plugin.egg-info/top_level.txt
x netbox-healthcheck-plugin-0.1.1/pyproject.toml
x netbox-healthcheck-plugin-0.1.1/setup.cfg
x netbox-healthcheck-plugin-0.1.1/tests/
x netbox-healthcheck-plugin-0.1.1/tests/__init__.py
x netbox-healthcheck-plugin-0.1.1/tests/test_netbox_healthcheck_plugin.py
$ python3 -m venv .venv
$ source .venv/bin/activate
$ pip install .
Processing /Volumes/Code/netbox-healthcheck-plugin
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting django-health-check<4,>=3 (from netbox-healthcheck-plugin==0.1.1)
  Using cached django_health_check-3.17.0-py2.py3-none-any.whl (29 kB)
Collecting django>=2.2 (from django-health-check<4,>=3->netbox-healthcheck-plugin==0.1.1)
  Using cached Django-4.2.7-py3-none-any.whl.metadata (4.1 kB)
Collecting asgiref<4,>=3.6.0 (from django>=2.2->django-health-check<4,>=3->netbox-healthcheck-plugin==0.1.1)
  Using cached asgiref-3.7.2-py3-none-any.whl.metadata (9.2 kB)
Collecting sqlparse>=0.3.1 (from django>=2.2->django-health-check<4,>=3->netbox-healthcheck-plugin==0.1.1)
  Using cached sqlparse-0.4.4-py3-none-any.whl (41 kB)
Using cached Django-4.2.7-py3-none-any.whl (8.0 MB)
Using cached asgiref-3.7.2-py3-none-any.whl (24 kB)
Building wheels for collected packages: netbox-healthcheck-plugin
  Building wheel for netbox-healthcheck-plugin (pyproject.toml) ... done
  Created wheel for netbox-healthcheck-plugin: filename=netbox_healthcheck_plugin-0.1.1-py3-none-any.whl size=7775 sha256=1b454a6ca434f1ac63272d83ffaa0ebb180563f92e6b544be5527df36d93e1f8
  Stored in directory: /Users/brandonbennett/Library/Caches/pip/wheels/4a/d9/c5/02d6a3fd658fc2449b3d93aa1f47441e8c0d84d3efa5b500dd
Successfully built netbox-healthcheck-plugin
Installing collected packages: sqlparse, asgiref, django, django-health-check, netbox-healthcheck-plugin
Successfully installed asgiref-3.7.2 django-4.2.7 django-health-check-3.17.0 netbox-healthcheck-plugin-0.1.1 sqlparse-0.4.4
$ python
Python 3.11.6 (main, Nov  2 2023, 04:39:43) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import nebox_healthcheck_plugin
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'nebox_healthcheck_plugin'
>>> import netbox_healthcheck_plugin
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Volumes/Code/netbox-healthcheck-plugin/netbox_healthcheck_plugin/__init__.py", line 8, in <module>
    from extras.plugins import PluginConfig
ModuleNotFoundError: No module named 'extras'
>>>
```

Fixes: #7