### PR TITLE
fix Redis health checks for more complicated installs + handle deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## 0.3.0
 
+* BREAKING: Require django-health-check >= 3.23
+* BREAKING: Redis health checks now read directly from NetBox's `REDIS` configuration dict, rather than requiring a separate `REDIS_URL` Django setting
 * Replace `health_check.contrib.redis` with custom NetBox Redis health check backends
 * Add health checks for both Redis instances: `caching` and `tasks`
-* BREAKING: Redis health checks now read directly from NetBox's `REDIS` configuration dict, rather than requiring a separate `REDIS_URL` Django setting
+* Migrate off deprecated django-health-check APIs ahead of 4.x removal:
+  * `BaseHealthCheckBackend` → `HealthCheck` base class
+  * `MainView` → `HealthCheckView` with explicit `checks` list
+  * `identifier()` → `__repr__()`
+  * `add_error()` → raised exceptions
+  * Remove `plugin_dir` registry, `health_check.db`, and `health_check.contrib.migrations`
 
 ## 0.2.0 (2024-05006)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0
+
+* Replace `health_check.contrib.redis` with custom NetBox Redis health check backends
+* Add health checks for both Redis instances: `caching` and `tasks`
+* BREAKING: Redis health checks now read directly from NetBox's `REDIS` configuration dict, rather than requiring a separate `REDIS_URL` Django setting
+
 ## 0.2.0 (2024-05006)
 
 * Updates for NetBox v4.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,25 @@ NetBox exposes metrics at the `/healthcheck` HTTP endpoint under the plugin, e.g
 
 ## Features
 
-The features the plugin provides should be listed here.
+This plugin provides the following health checks:
+
+- **Database** - Verifies PostgreSQL database connectivity
+- **Migrations** - Checks for pending database migrations
+- **Redis Cache** - Verifies connectivity to the caching Redis instance
+- **Redis Tasks** - Verifies connectivity to the tasks/RQ Redis instance
+
+### Redis Health Checks
+
+NOTE: Previous versions of this plugin used a `REDIS_URL` setting for connectivity, but as of `0.3.0` it reads the Redis configuration directly from NetBox's settings.
+
+NetBox uses two Redis instances:
+- `caching` - Used for Django cache operations
+- `tasks` - Used for the RQ task queue (background workers)
+
+Both are checked automatically. The configuration supports:
+- `HOST`, `PORT`, `DATABASE` - Connection parameters
+- `USERNAME`, `PASSWORD` - Authentication (optional)
+- `SSL`, `INSECURE_SKIP_TLS_VERIFY`, `CA_CERT_PATH` - TLS settings (optional)
 
 ## Compatibility
 
@@ -21,7 +39,7 @@ The features the plugin provides should be listed here.
 |   3.4 - 3.7    |      0.1.0     |
 |   3.4 - 3.7    |      0.1.2     |
 |   3.4 - 3.7    |      0.1.3     |
-|   4.0.         |      0.2.0     |
+|   4.0+         |      0.2.0     |
 
 ## Installing
 

--- a/netbox_healthcheck_plugin/__init__.py
+++ b/netbox_healthcheck_plugin/__init__.py
@@ -16,10 +16,6 @@ class HealthCheckConfig(PluginConfig):
     base_url = 'netbox_healthcheck_plugin'
     django_apps = [
         'health_check',
-        'health_check.db',
-        'health_check.contrib.migrations',
-        # Use our custom Redis backend that reads from NetBox's REDIS config
-        # instead of health_check.contrib.redis which expects REDIS_URL
         'netbox_healthcheck_plugin.backends',
     ]
     min_version = "v4.0-beta1"

--- a/netbox_healthcheck_plugin/__init__.py
+++ b/netbox_healthcheck_plugin/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Arthur Hanson"""
 __email__ = 'ahanson@netboxlabs.com'
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 
 from netbox.plugins import PluginConfig
@@ -18,7 +18,9 @@ class HealthCheckConfig(PluginConfig):
         'health_check',
         'health_check.db',
         'health_check.contrib.migrations',
-        'health_check.contrib.redis',
+        # Use our custom Redis backend that reads from NetBox's REDIS config
+        # instead of health_check.contrib.redis which expects REDIS_URL
+        'netbox_healthcheck_plugin.backends',
     ]
     min_version = "v4.0-beta1"
 

--- a/netbox_healthcheck_plugin/backends/__init__.py
+++ b/netbox_healthcheck_plugin/backends/__init__.py
@@ -1,0 +1,15 @@
+"""Custom health check backends for NetBox."""
+
+from .redis import (
+    BaseNetBoxRedisHealthCheck,
+    NetBoxRedisCacheHealthCheck,
+    NetBoxRedisTasksHealthCheck,
+    NetBoxRedisHealthCheck,  # Backwards compatibility alias
+)
+
+__all__ = [
+    'BaseNetBoxRedisHealthCheck',
+    'NetBoxRedisCacheHealthCheck',
+    'NetBoxRedisTasksHealthCheck',
+    'NetBoxRedisHealthCheck',
+]

--- a/netbox_healthcheck_plugin/backends/apps.py
+++ b/netbox_healthcheck_plugin/backends/apps.py
@@ -1,18 +1,11 @@
 """Django app configuration for custom health check backends."""
 
 from django.apps import AppConfig
-from health_check.plugins import plugin_dir
 
 
 class NetBoxRedisHealthCheckConfig(AppConfig):
-    """App config that registers the NetBox Redis health check backends."""
+    """App config for the NetBox Redis health check backends."""
 
     name = 'netbox_healthcheck_plugin.backends'
     label = 'netbox_healthcheck_backends'
     verbose_name = 'NetBox Health Check Backends'
-
-    def ready(self):
-        from .redis import NetBoxRedisCacheHealthCheck, NetBoxRedisTasksHealthCheck
-        # Register health checks for both Redis instances used by NetBox
-        plugin_dir.register(NetBoxRedisCacheHealthCheck)
-        plugin_dir.register(NetBoxRedisTasksHealthCheck)

--- a/netbox_healthcheck_plugin/backends/apps.py
+++ b/netbox_healthcheck_plugin/backends/apps.py
@@ -1,0 +1,18 @@
+"""Django app configuration for custom health check backends."""
+
+from django.apps import AppConfig
+from health_check.plugins import plugin_dir
+
+
+class NetBoxRedisHealthCheckConfig(AppConfig):
+    """App config that registers the NetBox Redis health check backends."""
+
+    name = 'netbox_healthcheck_plugin.backends'
+    label = 'netbox_healthcheck_backends'
+    verbose_name = 'NetBox Health Check Backends'
+
+    def ready(self):
+        from .redis import NetBoxRedisCacheHealthCheck, NetBoxRedisTasksHealthCheck
+        # Register health checks for both Redis instances used by NetBox
+        plugin_dir.register(NetBoxRedisCacheHealthCheck)
+        plugin_dir.register(NetBoxRedisTasksHealthCheck)

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -7,7 +7,7 @@ DATABASE, PASSWORD, etc. fields rather than a connection URL.
 """
 
 from django.conf import settings
-from health_check.backends import BaseHealthCheckBackend
+from health_check.backends import HealthCheck
 from health_check.exceptions import ServiceUnavailable
 
 
@@ -66,7 +66,7 @@ def build_redis_url_options(redis_config: dict) -> dict:
     return options
 
 
-class BaseNetBoxRedisHealthCheck(BaseHealthCheckBackend):
+class BaseNetBoxRedisHealthCheck(HealthCheck):
     """
     Base health check backend for Redis that reads from NetBox's REDIS configuration.
 
@@ -92,18 +92,17 @@ class BaseNetBoxRedisHealthCheck(BaseHealthCheckBackend):
         try:
             import redis
         except ImportError:
-            self.add_error(ServiceUnavailable("redis library not installed"))
-            return
+            raise ServiceUnavailable("redis library not installed")
 
         try:
             connection = redis.Redis.from_url(self._redis_url, **self._redis_url_options)
             connection.ping()
         except redis.ConnectionError as e:
-            self.add_error(ServiceUnavailable(f"Redis connection error: {e}"))
+            raise ServiceUnavailable(f"Redis connection error: {e}")
         except Exception as e:
-            self.add_error(ServiceUnavailable(f"Redis error: {e}"))
+            raise ServiceUnavailable(f"Redis error: {e}")
 
-    def identifier(self):
+    def __repr__(self):
         """Return a unique identifier for this health check."""
         return f"redis:{self.redis_config_key}"
 

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -1,0 +1,124 @@
+"""
+Redis health check backend for NetBox.
+
+This backend reads Redis connection settings from NetBox's REDIS configuration
+dict instead of expecting a REDIS_URL setting. NetBox uses separate HOST, PORT,
+DATABASE, PASSWORD, etc. fields rather than a connection URL.
+"""
+
+from django.conf import settings
+from health_check.backends import BaseHealthCheckBackend
+from health_check.exceptions import ServiceUnavailable
+
+
+def build_redis_url_from_config(redis_config: dict) -> str:
+    """
+    Build a Redis URL from NetBox's REDIS configuration dict.
+
+    Args:
+        redis_config: Dict with HOST, PORT, DATABASE, PASSWORD, USERNAME, SSL keys
+
+    Returns:
+        Redis URL string (e.g., "redis://host:6379/0" or "rediss://user:pass@host:6379/0")
+    """
+    host = redis_config.get('HOST', 'localhost')
+    port = redis_config.get('PORT', 6379)
+    database = redis_config.get('DATABASE', 0)
+    password = redis_config.get('PASSWORD', '')
+    username = redis_config.get('USERNAME', '')
+    use_ssl = redis_config.get('SSL', False)
+
+    scheme = 'rediss' if use_ssl else 'redis'
+
+    auth = ''
+    if password:
+        if username:
+            auth = f'{username}:{password}@'
+        else:
+            auth = f':{password}@'
+    elif username:
+        auth = f'{username}@'
+
+    return f'{scheme}://{auth}{host}:{port}/{database}'
+
+
+def build_redis_url_options(redis_config: dict) -> dict:
+    """
+    Build Redis connection options for SSL/TLS from NetBox's REDIS configuration.
+
+    Args:
+        redis_config: Dict with SSL, INSECURE_SKIP_TLS_VERIFY, CA_CERT_PATH keys
+
+    Returns:
+        Dict of redis-py connection options for SSL/TLS
+    """
+    options = {}
+    use_ssl = redis_config.get('SSL', False)
+
+    if use_ssl:
+        import ssl
+        if redis_config.get('INSECURE_SKIP_TLS_VERIFY', False):
+            options['ssl_cert_reqs'] = ssl.CERT_NONE
+        ca_cert = redis_config.get('CA_CERT_PATH', '')
+        if ca_cert:
+            options['ssl_ca_certs'] = ca_cert
+
+    return options
+
+
+class BaseNetBoxRedisHealthCheck(BaseHealthCheckBackend):
+    """
+    Base health check backend for Redis that reads from NetBox's REDIS configuration.
+
+    NetBox stores Redis configuration in settings.REDIS as a dict with 'caching'
+    and 'tasks' keys, each containing HOST, PORT, DATABASE, PASSWORD, etc.
+
+    Subclasses should set `redis_config_key` to specify which Redis instance to check.
+    """
+
+    redis_config_key: str = 'caching'
+
+    def __init__(self):
+        super().__init__()
+        # Build connection parameters from NetBox's REDIS config at instantiation time
+        redis_settings = getattr(settings, 'REDIS', {})
+        redis_config = redis_settings.get(self.redis_config_key, {})
+
+        self._redis_url = build_redis_url_from_config(redis_config)
+        self._redis_url_options = build_redis_url_options(redis_config)
+
+    def check_status(self):
+        """Check Redis connectivity by issuing a PING command."""
+        try:
+            import redis
+        except ImportError:
+            self.add_error(ServiceUnavailable("redis library not installed"))
+            return
+
+        try:
+            connection = redis.Redis.from_url(self._redis_url, **self._redis_url_options)
+            connection.ping()
+        except redis.ConnectionError as e:
+            self.add_error(ServiceUnavailable(f"Redis connection error: {e}"))
+        except Exception as e:
+            self.add_error(ServiceUnavailable(f"Redis error: {e}"))
+
+    def identifier(self):
+        """Return a unique identifier for this health check."""
+        return f"redis:{self.redis_config_key}"
+
+
+class NetBoxRedisCacheHealthCheck(BaseNetBoxRedisHealthCheck):
+    """Health check for NetBox's caching Redis instance."""
+
+    redis_config_key = 'caching'
+
+
+class NetBoxRedisTasksHealthCheck(BaseNetBoxRedisHealthCheck):
+    """Health check for NetBox's tasks/RQ Redis instance."""
+
+    redis_config_key = 'tasks'
+
+
+# Backwards compatibility alias
+NetBoxRedisHealthCheck = NetBoxRedisCacheHealthCheck

--- a/netbox_healthcheck_plugin/templates/netbox_healthcheck_plugin/healthcheck.html
+++ b/netbox_healthcheck_plugin/templates/netbox_healthcheck_plugin/healthcheck.html
@@ -76,7 +76,7 @@
                     {% endif %}
                   </span>
                 </td>
-                <td>{{ plugin.identifier }}</td>
+                <td>{{ plugin }}</td>
                 <td>{{ plugin.pretty_status | linebreaks }}</td>
                 <td class="align-right">{{ plugin.time_taken|floatformat:4 }} seconds</td>
               </tr>

--- a/netbox_healthcheck_plugin/views.py
+++ b/netbox_healthcheck_plugin/views.py
@@ -1,6 +1,10 @@
-from django.views.generic import View
-from health_check.views import MainView
+from health_check.views import HealthCheckView
 
 
-class HealthCheckListView(MainView):
+class HealthCheckListView(HealthCheckView):
     template_name = 'netbox_healthcheck_plugin/healthcheck.html'
+    checks = [
+        'health_check.Database',
+        'netbox_healthcheck_plugin.backends.redis.NetBoxRedisCacheHealthCheck',
+        'netbox_healthcheck_plugin.backends.redis.NetBoxRedisTasksHealthCheck',
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name =  "netbox-healthcheck-plugin"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     {name = "Arthur Hanson", email = "ahanson@netboxlabs.com"},
 ]
@@ -27,7 +27,8 @@ classifiers=[
 requires-python = ">=3.10.0"
 
 dependencies = [
-    'django-health-check >= 3,<4'
+    'django-health-check >= 3,<4',
+    'redis >= 4.0',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers=[
 requires-python = ">=3.10.0"
 
 dependencies = [
-    'django-health-check >= 3,<4',
+    'django-health-check >= 3.23,<4',
     'redis >= 4.0',
 ]
 

--- a/tests/test_netbox_healthcheck_plugin.py
+++ b/tests/test_netbox_healthcheck_plugin.py
@@ -2,4 +2,226 @@
 
 """Tests for `netbox_healthcheck_plugin` package."""
 
-from netbox_healthcheck_plugin import netbox_healthcheck_plugin
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestBuildRedisUrl:
+    """Tests for Redis URL building from NetBox config."""
+
+    def test_basic_config(self):
+        """Test basic Redis config without auth."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        config = {
+            'HOST': 'redis.example.com',
+            'PORT': 6379,
+            'DATABASE': 0,
+        }
+        url = build_redis_url_from_config(config)
+        assert url == 'redis://redis.example.com:6379/0'
+
+    def test_with_password(self):
+        """Test Redis config with password only."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        config = {
+            'HOST': 'redis.example.com',
+            'PORT': 6379,
+            'DATABASE': 1,
+            'PASSWORD': 'secret',
+        }
+        url = build_redis_url_from_config(config)
+        assert url == 'redis://:secret@redis.example.com:6379/1'
+
+    def test_with_username_and_password(self):
+        """Test Redis config with username and password."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        config = {
+            'HOST': 'redis.example.com',
+            'PORT': 6379,
+            'DATABASE': 2,
+            'USERNAME': 'redisuser',
+            'PASSWORD': 'secret',
+        }
+        url = build_redis_url_from_config(config)
+        assert url == 'redis://redisuser:secret@redis.example.com:6379/2'
+
+    def test_with_ssl(self):
+        """Test Redis config with SSL enabled."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        config = {
+            'HOST': 'redis.example.com',
+            'PORT': 6380,
+            'DATABASE': 0,
+            'SSL': True,
+        }
+        url = build_redis_url_from_config(config)
+        assert url == 'rediss://redis.example.com:6380/0'
+
+    def test_defaults(self):
+        """Test that defaults are applied for missing config."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        config = {}
+        url = build_redis_url_from_config(config)
+        assert url == 'redis://localhost:6379/0'
+
+
+class TestBuildRedisUrlOptions:
+    """Tests for Redis URL options building."""
+
+    def test_no_ssl(self):
+        """Test that no options are returned without SSL."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_options
+
+        config = {'SSL': False}
+        options = build_redis_url_options(config)
+        assert options == {}
+
+    def test_ssl_insecure(self):
+        """Test SSL with insecure skip verify."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_options
+        import ssl
+
+        config = {
+            'SSL': True,
+            'INSECURE_SKIP_TLS_VERIFY': True,
+        }
+        options = build_redis_url_options(config)
+        assert options.get('ssl_cert_reqs') == ssl.CERT_NONE
+
+    def test_ssl_with_ca_cert(self):
+        """Test SSL with CA certificate path."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_options
+
+        config = {
+            'SSL': True,
+            'CA_CERT_PATH': '/etc/ssl/certs/ca-bundle.crt',
+        }
+        options = build_redis_url_options(config)
+        assert options.get('ssl_ca_certs') == '/etc/ssl/certs/ca-bundle.crt'
+
+
+class TestNetBoxRedisCacheHealthCheck:
+    """Tests for the NetBox Redis cache health check backend."""
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_reads_from_caching_config(self, mock_settings):
+        """Test that the backend reads from NetBox's REDIS caching config."""
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {
+            'caching': {
+                'HOST': 'cache-redis-host',
+                'PORT': 6379,
+                'DATABASE': 1,
+            },
+            'tasks': {
+                'HOST': 'tasks-redis-host',
+                'PORT': 6380,
+                'DATABASE': 2,
+            },
+        }
+
+        backend = NetBoxRedisCacheHealthCheck()
+        assert backend._redis_url == 'redis://cache-redis-host:6379/1'
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_identifier(self, mock_settings):
+        """Test that the identifier is redis:caching."""
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'localhost'}}
+
+        backend = NetBoxRedisCacheHealthCheck()
+        assert backend.identifier() == 'redis:caching'
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    @patch('netbox_healthcheck_plugin.backends.redis.redis')
+    def test_check_status_success(self, mock_redis_module, mock_settings):
+        """Test successful health check."""
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'localhost'}}
+        mock_connection = MagicMock()
+        mock_redis_module.Redis.from_url.return_value = mock_connection
+
+        backend = NetBoxRedisCacheHealthCheck()
+        backend.check_status()
+
+        mock_redis_module.Redis.from_url.assert_called_once()
+        mock_connection.ping.assert_called_once()
+        assert len(backend.errors) == 0
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_check_status_connection_error(self, mock_settings):
+        """Test health check with connection error."""
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+        import redis
+
+        mock_settings.REDIS = {'caching': {'HOST': 'nonexistent-host'}}
+
+        backend = NetBoxRedisCacheHealthCheck()
+
+        with patch.object(redis.Redis, 'from_url') as mock_from_url:
+            mock_from_url.side_effect = redis.ConnectionError("Connection refused")
+            backend.check_status()
+
+        assert len(backend.errors) == 1
+
+
+class TestNetBoxRedisTasksHealthCheck:
+    """Tests for the NetBox Redis tasks health check backend."""
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_reads_from_tasks_config(self, mock_settings):
+        """Test that the backend reads from NetBox's REDIS tasks config."""
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisTasksHealthCheck
+
+        mock_settings.REDIS = {
+            'caching': {
+                'HOST': 'cache-redis-host',
+                'PORT': 6379,
+                'DATABASE': 1,
+            },
+            'tasks': {
+                'HOST': 'tasks-redis-host',
+                'PORT': 6380,
+                'DATABASE': 2,
+            },
+        }
+
+        backend = NetBoxRedisTasksHealthCheck()
+        assert backend._redis_url == 'redis://tasks-redis-host:6380/2'
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_identifier(self, mock_settings):
+        """Test that the identifier is redis:tasks."""
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisTasksHealthCheck
+
+        mock_settings.REDIS = {'tasks': {'HOST': 'localhost'}}
+
+        backend = NetBoxRedisTasksHealthCheck()
+        assert backend.identifier() == 'redis:tasks'
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    @patch('netbox_healthcheck_plugin.backends.redis.redis')
+    def test_check_status_success(self, mock_redis_module, mock_settings):
+        """Test successful health check."""
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisTasksHealthCheck
+
+        mock_settings.REDIS = {'tasks': {'HOST': 'localhost'}}
+        mock_connection = MagicMock()
+        mock_redis_module.Redis.from_url.return_value = mock_connection
+
+        backend = NetBoxRedisTasksHealthCheck()
+        backend.check_status()
+
+        mock_redis_module.Redis.from_url.assert_called_once()
+        mock_connection.ping.assert_called_once()
+        assert len(backend.errors) == 0
+
+

--- a/tests/test_netbox_healthcheck_plugin.py
+++ b/tests/test_netbox_healthcheck_plugin.py
@@ -130,14 +130,14 @@ class TestNetBoxRedisCacheHealthCheck:
         assert backend._redis_url == 'redis://cache-redis-host:6379/1'
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
-    def test_identifier(self, mock_settings):
-        """Test that the identifier is redis:caching."""
+    def test_repr(self, mock_settings):
+        """Test that repr is redis:caching."""
         from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
 
         mock_settings.REDIS = {'caching': {'HOST': 'localhost'}}
 
         backend = NetBoxRedisCacheHealthCheck()
-        assert backend.identifier() == 'redis:caching'
+        assert repr(backend) == 'redis:caching'
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
     @patch('netbox_healthcheck_plugin.backends.redis.redis')
@@ -160,6 +160,7 @@ class TestNetBoxRedisCacheHealthCheck:
     def test_check_status_connection_error(self, mock_settings):
         """Test health check with connection error."""
         from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+        from health_check.exceptions import ServiceUnavailable
         import redis
 
         mock_settings.REDIS = {'caching': {'HOST': 'nonexistent-host'}}
@@ -168,9 +169,8 @@ class TestNetBoxRedisCacheHealthCheck:
 
         with patch.object(redis.Redis, 'from_url') as mock_from_url:
             mock_from_url.side_effect = redis.ConnectionError("Connection refused")
-            backend.check_status()
-
-        assert len(backend.errors) == 1
+            with pytest.raises(ServiceUnavailable):
+                backend.check_status()
 
 
 class TestNetBoxRedisTasksHealthCheck:
@@ -198,14 +198,14 @@ class TestNetBoxRedisTasksHealthCheck:
         assert backend._redis_url == 'redis://tasks-redis-host:6380/2'
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
-    def test_identifier(self, mock_settings):
-        """Test that the identifier is redis:tasks."""
+    def test_repr(self, mock_settings):
+        """Test that repr is redis:tasks."""
         from netbox_healthcheck_plugin.backends.redis import NetBoxRedisTasksHealthCheck
 
         mock_settings.REDIS = {'tasks': {'HOST': 'localhost'}}
 
         backend = NetBoxRedisTasksHealthCheck()
-        assert backend.identifier() == 'redis:tasks'
+        assert repr(backend) == 'redis:tasks'
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
     @patch('netbox_healthcheck_plugin.backends.redis.redis')


### PR DESCRIPTION
The `netbox-healthcheck-plugin` relies on `django-health-check` which has been preparing for a 4.0 release. In the process, they are deprecating a number of things and since dependencies aren't pinned, getting a newer `3.21` (or higher) version as a transient dependency means that some things don't work anymore (for example: plugin name display in the UI).

This PR updates to use the latest APIs in preparation for the 4.0 move, and also fixes an issue with attempting to health check Redis when more complicated SSL configs or alternate database numbers are used.