### PR TITLE
Update to django-health-check 4.2.2 and fix Redis URL building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+* Require `django-health-check >= 4.2.2` — v3 is no longer supported
+* Removed the `NetBoxRedisHealthCheck` backwards-compatibility alias (use `NetBoxRedisCacheHealthCheck`)
+* Default `checks` path for the cache backend changed from `health_check.cache.backends.CacheBackend` to `health_check.Cache`. Users who pinned `checks` in `PLUGINS_CONFIG` must update it.
+* `health_check.cache` is no longer registered as a Django app; only `health_check` is installed.
+
+### Features
+* Redis password is URL-encoded when constructing the connection URL, so passwords containing special characters no longer break the connection ([#20](https://github.com/netbox-community/netbox-healthcheck-plugin/pull/20) by [@tacerus](https://github.com/tacerus)).
+
+### Internal
+* `BaseNetBoxRedisHealthCheck` is now a dataclass, and `check_status` has been renamed to `run` to match django-health-check v4's API.
+
 ## 0.3.0 (2026-02-06)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ PLUGINS_CONFIG = {
     "netbox_healthcheck_plugin": {
         "checks": [
             "health_check.Database",
-            "health_check.cache.backends.CacheBackend",
+            "health_check.Cache",
             "netbox_healthcheck_plugin.backends.redis.NetBoxRedisCacheHealthCheck",
             "netbox_healthcheck_plugin.backends.redis.NetBoxRedisTasksHealthCheck",
         ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+* Require `django-health-check >= 4.2.2` — v3 is no longer supported
+* Removed the `NetBoxRedisHealthCheck` backwards-compatibility alias (use `NetBoxRedisCacheHealthCheck`)
+* Default `checks` path for the cache backend changed from `health_check.cache.backends.CacheBackend` to `health_check.Cache`. Users who pinned `checks` in `PLUGINS_CONFIG` must update it.
+* `health_check.cache` is no longer registered as a Django app; only `health_check` is installed.
+
+### Features
+* Redis password is URL-encoded when constructing the connection URL, so passwords containing special characters no longer break the connection ([#20](https://github.com/netbox-community/netbox-healthcheck-plugin/pull/20) by [@tacerus](https://github.com/tacerus)).
+
+### Internal
+* `BaseNetBoxRedisHealthCheck` is now a dataclass, and `check_status` has been renamed to `run` to match django-health-check v4's API.
+
 ## 0.3.0 (2026-02-06)
 
 ### Breaking Changes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ PLUGINS_CONFIG = {
     "netbox_healthcheck_plugin": {
         "checks": [
             "health_check.Database",
-            "health_check.cache.backends.CacheBackend",
+            "health_check.Cache",
             "netbox_healthcheck_plugin.backends.redis.NetBoxRedisCacheHealthCheck",
             "netbox_healthcheck_plugin.backends.redis.NetBoxRedisTasksHealthCheck",
         ]
@@ -48,7 +48,7 @@ Verifies PostgreSQL database connectivity by performing a simple database query.
 - Database authentication succeeds
 - Basic database operations work
 
-#### `health_check.cache.backends.CacheBackend`
+#### `health_check.Cache`
 
 Tests Django cache framework operations (set/get) using NetBox's configured cache backend (typically Redis).
 
@@ -89,7 +89,7 @@ PLUGINS_CONFIG = {
         "checks": [
             # Default checks
             "health_check.Database",
-            "health_check.cache.backends.CacheBackend",
+            "health_check.Cache",
             "netbox_healthcheck_plugin.backends.redis.NetBoxRedisCacheHealthCheck",
             "netbox_healthcheck_plugin.backends.redis.NetBoxRedisTasksHealthCheck",
 
@@ -114,19 +114,18 @@ For programmatic access, request the health check endpoint with `Accept: applica
 curl -H "Accept: application/json" https://netbox.example.com/plugins/netbox_healthcheck_plugin/healthcheck/
 ```
 
-Response format:
+Response format (v4 returns a flat map keyed by each check's `repr`):
 
 ```json
 {
-  "status": "working",
-  "checks": {
-    "Database": "working",
-    "CacheBackend": "working",
-    "NetBoxRedisCacheHealthCheck": "working",
-    "NetBoxRedisTasksHealthCheck": "working"
-  }
+  "Database(alias='default')": "OK",
+  "Cache(alias='default')": "OK",
+  "redis:caching": "OK",
+  "redis:tasks": "OK"
 }
 ```
+
+Failed checks show the error message instead of `OK`.
 
 ### HTTP Status Codes
 
@@ -137,29 +136,31 @@ Response format:
 
 To create your own health check:
 
-1. Create a new class extending `health_check.backends.BaseHealthCheckBackend`:
+1. Create a new dataclass extending `health_check.HealthCheck` and implement `run`:
 
 ```python
-from health_check.backends import BaseHealthCheckBackend
+import dataclasses
+
+import requests
+from health_check import HealthCheck
 from health_check.exceptions import ServiceUnavailable
 
-class MyCustomHealthCheck(BaseHealthCheckBackend):
-    #: The status endpoints will respond with a 200 status code
-    #: even if the check errors.
-    critical_service = False
 
-    def check_status(self):
-        # Perform your health check logic
+@dataclasses.dataclass
+class MyCustomHealthCheck(HealthCheck):
+    url: str = "https://api.example.com/status"
+
+    def run(self):
+        # Raise ServiceUnavailable to signal failure. Returning None signals success.
         try:
-            # Example: check external API
-            response = requests.get('https://api.example.com/status', timeout=5)
-            if response.status_code != 200:
-                self.add_error(ServiceUnavailable("API returned non-200 status"))
-        except Exception as e:
-            self.add_error(ServiceUnavailable("API is unreachable"), e)
+            response = requests.get(self.url, timeout=5)
+        except requests.RequestException as e:
+            raise ServiceUnavailable("API is unreachable") from e
+        if response.status_code != 200:
+            raise ServiceUnavailable("API returned non-200 status")
 
-    def identifier(self):
-        return "MyCustomCheck"
+    def __repr__(self):
+        return f"MyCustomCheck({self.url})"
 ```
 
 2. Add to your plugin configuration:
@@ -169,7 +170,7 @@ PLUGINS_CONFIG = {
     "netbox_healthcheck_plugin": {
         "checks": [
             "health_check.Database",
-            "health_check.cache.backends.CacheBackend",
+            "health_check.Cache",
             "netbox_healthcheck_plugin.backends.redis.NetBoxRedisCacheHealthCheck",
             "netbox_healthcheck_plugin.backends.redis.NetBoxRedisTasksHealthCheck",
             "my_plugin.health.MyCustomHealthCheck",
@@ -178,7 +179,7 @@ PLUGINS_CONFIG = {
 }
 ```
 
-For more details on creating health checks, see the [django-health-check documentation](https://django-health-check.readthedocs.io/).
+For more details on creating health checks, see the [django-health-check documentation](https://codingjoe.dev/django-health-check/).
 
 ## Next Steps
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,7 +116,7 @@ If you see import errors:
 
 1. Check that all dependencies are installed:
    ```bash
-   pip install django-health-check>=3.23.0 redis>=4.0
+   pip install 'django-health-check>=4.2.2' 'redis>=4.0'
    ```
 
 2. Verify your NetBox version meets the minimum requirement (>= 4.5.0)

--- a/netbox_healthcheck_plugin/__init__.py
+++ b/netbox_healthcheck_plugin/__init__.py
@@ -18,14 +18,13 @@ class HealthCheckConfig(PluginConfig):
     base_url = 'netbox_healthcheck_plugin'
     django_apps = [
         'health_check',
-        'health_check.cache',
         'netbox_healthcheck_plugin.backends',
     ]
     min_version = '4.5.0'
     default_settings = {
         'checks': [
             'health_check.Database',
-            'health_check.cache.backends.CacheBackend',
+            'health_check.Cache',
             'netbox_healthcheck_plugin.backends.redis.NetBoxRedisCacheHealthCheck',
             'netbox_healthcheck_plugin.backends.redis.NetBoxRedisTasksHealthCheck',
         ]

--- a/netbox_healthcheck_plugin/backends/__init__.py
+++ b/netbox_healthcheck_plugin/backends/__init__.py
@@ -3,7 +3,6 @@
 from .redis import (
     BaseNetBoxRedisHealthCheck,
     NetBoxRedisCacheHealthCheck,
-    NetBoxRedisHealthCheck,  # Backwards compatibility alias
     NetBoxRedisTasksHealthCheck,
 )
 
@@ -11,5 +10,4 @@ __all__ = [
     'BaseNetBoxRedisHealthCheck',
     'NetBoxRedisCacheHealthCheck',
     'NetBoxRedisTasksHealthCheck',
-    'NetBoxRedisHealthCheck',
 ]

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -123,8 +123,8 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
             connection.ping()
         except redis.ConnectionError as e:
             raise ServiceUnavailable(f'Redis connection error to {display_url}: {e}') from e
-        except Exception as e:
-            raise ServiceUnavailable(f'Redis error connecting to {display_url}: {e}') from e
+        except redis.RedisError as e:
+            raise ServiceUnavailable(f'Redis error ({type(e).__name__}) for {display_url}: {e}') from e
 
     def __repr__(self):
         """Return a unique identifier for this health check."""

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -118,13 +118,17 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
             if len(auth_parts) == 2:
                 display_url = f'{auth_parts[0]}:***@{parts[1]}'
 
+        def _safe_msg(exc: Exception) -> str:
+            """Strip the real URL (which contains the password) from the error message."""
+            return str(exc).replace(self._redis_url, display_url)
+
         try:
             connection = redis.Redis.from_url(self._redis_url, **self._redis_url_options)
             connection.ping()
         except redis.ConnectionError as e:
-            raise ServiceUnavailable(f'Redis connection error to {display_url}: {e}') from e
+            raise ServiceUnavailable(f'Redis connection error to {display_url}: {_safe_msg(e)}') from None
         except redis.RedisError as e:
-            raise ServiceUnavailable(f'Redis error ({type(e).__name__}) for {display_url}: {e}') from e
+            raise ServiceUnavailable(f'Redis error ({type(e).__name__}) for {display_url}: {_safe_msg(e)}') from None
 
     def __repr__(self):
         """Return a unique identifier for this health check."""

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -101,11 +101,22 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
                 f"No Redis configuration found for '{self.redis_config_key}' in settings.REDIS"
             )
             self._redis_url = ''
+            self._display_url = ''
             self._redis_url_options: dict = {}
             return
 
         self._config_error = None
         self._redis_url = build_redis_url_from_config(redis_config)
+        # Precompute a password-masked URL for error messages by rebuilding from a
+        # config with the password replaced. Rebuilding (rather than parsing the
+        # real URL) avoids edge cases with username-only URLs where the scheme's
+        # colon gets misinterpreted as an auth separator.
+        if redis_config.get('PASSWORD'):
+            # Use an alphanumeric mask so url-encoding leaves it intact.
+            masked_config = dict(redis_config, PASSWORD='REDACTED')
+            self._display_url = build_redis_url_from_config(masked_config)
+        else:
+            self._display_url = self._redis_url
         self._redis_url_options = build_redis_url_options(redis_config)
 
     def run(self):
@@ -118,27 +129,18 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
         except ImportError as e:
             raise ServiceUnavailable('redis library not installed') from e
 
-        # Mask password in URL for error messages
-        display_url = self._redis_url
-        if '@' in display_url and ':' in display_url.split('@')[0]:
-            # Replace password with asterisks
-            parts = display_url.split('@')
-            auth_parts = parts[0].rsplit(':', 1)
-            if len(auth_parts) == 2:
-                display_url = f'{auth_parts[0]}:***@{parts[1]}'
-
         def _safe_msg(exc: Exception) -> str:
             """Strip the real URL (which contains the password) from the error message."""
-            return str(exc).replace(self._redis_url, display_url)
+            return str(exc).replace(self._redis_url, self._display_url)
 
         with closing(redis.Redis.from_url(self._redis_url, **self._redis_url_options)) as connection:
             try:
                 connection.ping()
             except redis.ConnectionError as e:
-                raise ServiceUnavailable(f'Redis connection error to {display_url}: {_safe_msg(e)}') from None
+                raise ServiceUnavailable(f'Redis connection error to {self._display_url}: {_safe_msg(e)}') from None
             except redis.RedisError as e:
                 raise ServiceUnavailable(
-                    f'Redis error ({type(e).__name__}) for {display_url}: {_safe_msg(e)}'
+                    f'Redis error ({type(e).__name__}) for {self._display_url}: {_safe_msg(e)}'
                 ) from None
 
     def __repr__(self):

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -32,8 +32,8 @@ def build_redis_url_from_config(redis_config: dict) -> str:
     host = redis_config.get('HOST', 'localhost')
     port = redis_config.get('PORT', 6379)
     database = redis_config.get('DATABASE', 0)
-    password = quote(redis_config.get('PASSWORD', ''))
-    username = redis_config.get('USERNAME', '')
+    password = quote(redis_config.get('PASSWORD', ''), safe='')
+    username = quote(redis_config.get('USERNAME', ''), safe='')
     use_ssl = redis_config.get('SSL', False)
 
     scheme = 'rediss' if use_ssl else 'redis'

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -7,7 +7,6 @@ DATABASE, PASSWORD, etc. fields rather than a connection URL.
 """
 
 import dataclasses
-import warnings
 from urllib.parse import quote
 
 from django.conf import settings
@@ -86,24 +85,33 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
     redis_config_key: str = 'caching'
 
     def __post_init__(self):
-        """Build connection parameters from NetBox's REDIS config at instantiation time."""
+        """Read and validate the NetBox Redis config at instantiation time.
+
+        If the expected key is missing from settings.REDIS we record the error
+        here and surface it from run(); we deliberately do NOT fall back to
+        localhost defaults, because that would let a misconfigured deployment
+        silently report healthy by pinging a different Redis (or nothing at all).
+        """
         redis_settings = getattr(settings, 'REDIS', {})
         redis_config = redis_settings.get(self.redis_config_key, {})
 
-        # Warn if using default configuration (empty config dict)
         if not redis_config:
-            warnings.warn(
-                f"No Redis configuration found for '{self.redis_config_key}' in settings.REDIS. "
-                f'Using defaults: localhost:6379/0. This may indicate a configuration issue.',
-                RuntimeWarning,
-                stacklevel=2,
+            self._config_error: str | None = (
+                f"No Redis configuration found for '{self.redis_config_key}' in settings.REDIS"
             )
+            self._redis_url = ''
+            self._redis_url_options: dict = {}
+            return
 
+        self._config_error = None
         self._redis_url = build_redis_url_from_config(redis_config)
         self._redis_url_options = build_redis_url_options(redis_config)
 
     def run(self):
         """Check Redis connectivity by issuing a PING command."""
+        if self._config_error:
+            raise ServiceUnavailable(self._config_error)
+
         try:
             import redis
         except ImportError as e:

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -6,10 +6,12 @@ dict instead of expecting a REDIS_URL setting. NetBox uses separate HOST, PORT,
 DATABASE, PASSWORD, etc. fields rather than a connection URL.
 """
 
+import dataclasses
+import warnings
 from urllib.parse import quote
 
 from django.conf import settings
-from health_check.backends import HealthCheck
+from health_check.base import HealthCheck
 from health_check.exceptions import ServiceUnavailable
 
 
@@ -70,6 +72,7 @@ def build_redis_url_options(redis_config: dict) -> dict:
     return options
 
 
+@dataclasses.dataclass(repr=False)
 class BaseNetBoxRedisHealthCheck(HealthCheck):
     """
     Base health check backend for Redis that reads from NetBox's REDIS configuration.
@@ -82,16 +85,13 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
 
     redis_config_key: str = 'caching'
 
-    def __init__(self):
-        super().__init__()
-        # Build connection parameters from NetBox's REDIS config at instantiation time
+    def __post_init__(self):
+        """Build connection parameters from NetBox's REDIS config at instantiation time."""
         redis_settings = getattr(settings, 'REDIS', {})
         redis_config = redis_settings.get(self.redis_config_key, {})
 
         # Warn if using default configuration (empty config dict)
         if not redis_config:
-            import warnings
-
             warnings.warn(
                 f"No Redis configuration found for '{self.redis_config_key}' in settings.REDIS. "
                 f'Using defaults: localhost:6379/0. This may indicate a configuration issue.',
@@ -102,7 +102,7 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
         self._redis_url = build_redis_url_from_config(redis_config)
         self._redis_url_options = build_redis_url_options(redis_config)
 
-    def check_status(self):
+    def run(self):
         """Check Redis connectivity by issuing a PING command."""
         try:
             import redis
@@ -131,17 +131,15 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
         return f'redis:{self.redis_config_key}'
 
 
+@dataclasses.dataclass(repr=False)
 class NetBoxRedisCacheHealthCheck(BaseNetBoxRedisHealthCheck):
     """Health check for NetBox's caching Redis instance."""
 
-    redis_config_key = 'caching'
+    redis_config_key: str = 'caching'
 
 
+@dataclasses.dataclass(repr=False)
 class NetBoxRedisTasksHealthCheck(BaseNetBoxRedisHealthCheck):
     """Health check for NetBox's tasks/RQ Redis instance."""
 
-    redis_config_key = 'tasks'
-
-
-# Backwards compatibility alias
-NetBoxRedisHealthCheck = NetBoxRedisCacheHealthCheck
+    redis_config_key: str = 'tasks'

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -7,6 +7,7 @@ DATABASE, PASSWORD, etc. fields rather than a connection URL.
 """
 
 import dataclasses
+from contextlib import closing
 from urllib.parse import quote
 
 from django.conf import settings
@@ -130,13 +131,15 @@ class BaseNetBoxRedisHealthCheck(HealthCheck):
             """Strip the real URL (which contains the password) from the error message."""
             return str(exc).replace(self._redis_url, display_url)
 
-        try:
-            connection = redis.Redis.from_url(self._redis_url, **self._redis_url_options)
-            connection.ping()
-        except redis.ConnectionError as e:
-            raise ServiceUnavailable(f'Redis connection error to {display_url}: {_safe_msg(e)}') from None
-        except redis.RedisError as e:
-            raise ServiceUnavailable(f'Redis error ({type(e).__name__}) for {display_url}: {_safe_msg(e)}') from None
+        with closing(redis.Redis.from_url(self._redis_url, **self._redis_url_options)) as connection:
+            try:
+                connection.ping()
+            except redis.ConnectionError as e:
+                raise ServiceUnavailable(f'Redis connection error to {display_url}: {_safe_msg(e)}') from None
+            except redis.RedisError as e:
+                raise ServiceUnavailable(
+                    f'Redis error ({type(e).__name__}) for {display_url}: {_safe_msg(e)}'
+                ) from None
 
     def __repr__(self):
         """Return a unique identifier for this health check."""

--- a/netbox_healthcheck_plugin/backends/redis.py
+++ b/netbox_healthcheck_plugin/backends/redis.py
@@ -6,6 +6,8 @@ dict instead of expecting a REDIS_URL setting. NetBox uses separate HOST, PORT,
 DATABASE, PASSWORD, etc. fields rather than a connection URL.
 """
 
+from urllib.parse import quote
+
 from django.conf import settings
 from health_check.backends import HealthCheck
 from health_check.exceptions import ServiceUnavailable
@@ -28,7 +30,7 @@ def build_redis_url_from_config(redis_config: dict) -> str:
     host = redis_config.get('HOST', 'localhost')
     port = redis_config.get('PORT', 6379)
     database = redis_config.get('DATABASE', 0)
-    password = redis_config.get('PASSWORD', '')
+    password = quote(redis_config.get('PASSWORD', ''))
     username = redis_config.get('USERNAME', '')
     use_ssl = redis_config.get('SSL', False)
 

--- a/netbox_healthcheck_plugin/templates/netbox_healthcheck_plugin/healthcheck.html
+++ b/netbox_healthcheck_plugin/templates/netbox_healthcheck_plugin/healthcheck.html
@@ -37,7 +37,7 @@
         <ul class="nav nav-tabs px-3">
           <li class="nav-item" role="presentation">
             <button class="nav-link active" id="object-list-tab" data-bs-toggle="tab" data-bs-target="#object-list" type="button" role="tab" aria-controls="edit-form" aria-selected="true">
-              Results {% badge table.page.paginator.count %}
+              Results {% badge results|length %}
             </button>
           </li>
         </ul>
@@ -65,20 +65,20 @@
             <th class="align-right">Time Taken</th>
           </thead>
           <tbody>
-            {% for plugin in plugins %}
+            {% for result in results %}
               <tr>
                 <td class="icons">
                   <span aria-hidden="true">
-                    {% if plugin.status %}
+                    {% if not result.error %}
                       &#9989;
                     {% else %}
                       &#10060;
                     {% endif %}
                   </span>
                 </td>
-                <td>{{ plugin }}</td>
-                <td>{{ plugin.pretty_status | linebreaks }}</td>
-                <td class="align-right">{{ plugin.time_taken|floatformat:4 }} seconds</td>
+                <td>{{ result.check|stringformat:'r' }}</td>
+                <td>{{ result.error|default_if_none:"OK"|linebreaks }}</td>
+                <td class="align-right">{{ result.time_taken|floatformat:4 }} seconds</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/netbox_healthcheck_plugin/tests/test_netbox_healthcheck_plugin.py
+++ b/netbox_healthcheck_plugin/tests/test_netbox_healthcheck_plugin.py
@@ -27,7 +27,7 @@ class TestHealthCheckPlugin(TestCase):
         self.assertGreater(len(default_checks), 0)
         # Verify default checks are present
         self.assertIn('health_check.Database', default_checks)
-        self.assertIn('health_check.cache.backends.CacheBackend', default_checks)
+        self.assertIn('health_check.Cache', default_checks)
         self.assertIn('netbox_healthcheck_plugin.backends.redis.NetBoxRedisCacheHealthCheck', default_checks)
         self.assertIn('netbox_healthcheck_plugin.backends.redis.NetBoxRedisTasksHealthCheck', default_checks)
 
@@ -51,7 +51,7 @@ class TestHealthCheckConfiguration(TestCase):
 
         default_checks = [
             'health_check.Database',
-            'health_check.cache.backends.CacheBackend',
+            'health_check.Cache',
             'netbox_healthcheck_plugin.backends.redis.NetBoxRedisCacheHealthCheck',
             'netbox_healthcheck_plugin.backends.redis.NetBoxRedisTasksHealthCheck',
         ]
@@ -231,7 +231,7 @@ class TestNetBoxRedisCacheHealthCheck(TestCase):
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
     @patch('redis.Redis.from_url')
-    def test_check_status_success(self, mock_from_url, mock_settings):
+    def test_run_success(self, mock_from_url, mock_settings):
         """Test successful health check."""
         from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
 
@@ -240,14 +240,14 @@ class TestNetBoxRedisCacheHealthCheck(TestCase):
         mock_from_url.return_value = mock_connection
 
         backend = NetBoxRedisCacheHealthCheck()
-        backend.check_status()
+        # run() returns None on success, raises on failure
+        self.assertIsNone(backend.run())
 
         mock_from_url.assert_called_once()
         mock_connection.ping.assert_called_once()
-        self.assertEqual(len(backend.errors), 0)
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
-    def test_check_status_connection_error(self, mock_settings):
+    def test_run_connection_error(self, mock_settings):
         """Test health check with connection error."""
         import redis
         from health_check.exceptions import ServiceUnavailable
@@ -261,7 +261,7 @@ class TestNetBoxRedisCacheHealthCheck(TestCase):
         with patch.object(redis.Redis, 'from_url') as mock_from_url:
             mock_from_url.side_effect = redis.ConnectionError('Connection refused')
             with self.assertRaises(ServiceUnavailable):
-                backend.check_status()
+                backend.run()
 
 
 class TestNetBoxRedisTasksHealthCheck(TestCase):
@@ -300,7 +300,7 @@ class TestNetBoxRedisTasksHealthCheck(TestCase):
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
     @patch('redis.Redis.from_url')
-    def test_check_status_success(self, mock_from_url, mock_settings):
+    def test_run_success(self, mock_from_url, mock_settings):
         """Test successful health check."""
         from netbox_healthcheck_plugin.backends.redis import NetBoxRedisTasksHealthCheck
 
@@ -309,8 +309,8 @@ class TestNetBoxRedisTasksHealthCheck(TestCase):
         mock_from_url.return_value = mock_connection
 
         backend = NetBoxRedisTasksHealthCheck()
-        backend.check_status()
+        # run() returns None on success, raises on failure
+        self.assertIsNone(backend.run())
 
         mock_from_url.assert_called_once()
         mock_connection.ping.assert_called_once()
-        self.assertEqual(len(backend.errors), 0)

--- a/netbox_healthcheck_plugin/tests/test_netbox_healthcheck_plugin.py
+++ b/netbox_healthcheck_plugin/tests/test_netbox_healthcheck_plugin.py
@@ -1,5 +1,6 @@
 """Tests for netbox_healthcheck_plugin package."""
 
+import sys
 from unittest.mock import MagicMock, patch
 
 from django.test import Client, TestCase
@@ -137,6 +138,19 @@ class TestBuildRedisUrl(TestCase):
         url = build_redis_url_from_config(config)
         self.assertEqual(url, 'redis://redisuser:secret@redis.example.com:6379/2')
 
+    def test_with_username_only(self):
+        """Test Redis config with username but no password."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        config = {
+            'HOST': 'redis.example.com',
+            'PORT': 6379,
+            'DATABASE': 0,
+            'USERNAME': 'redisuser',
+        }
+        url = build_redis_url_from_config(config)
+        self.assertEqual(url, 'redis://redisuser@redis.example.com:6379/0')
+
     def test_with_ssl(self):
         """Test Redis config with SSL enabled."""
         from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
@@ -151,12 +165,47 @@ class TestBuildRedisUrl(TestCase):
         self.assertEqual(url, 'rediss://redis.example.com:6380/0')
 
     def test_defaults(self):
-        """Test that defaults are applied for missing config."""
+        """build_redis_url_from_config applies redis-py defaults for missing keys."""
         from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
 
         config = {}
         url = build_redis_url_from_config(config)
         self.assertEqual(url, 'redis://localhost:6379/0')
+
+    def test_password_with_special_chars_is_urlencoded(self):
+        """Passwords with reserved URL characters must be percent-encoded."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        config = {
+            'HOST': 'redis.example.com',
+            'PORT': 6379,
+            'DATABASE': 0,
+            'PASSWORD': 'p@ss:w/rd!',
+        }
+        url = build_redis_url_from_config(config)
+        # @ -> %40, : -> %3A, / -> %2F, ! -> %21
+        self.assertEqual(url, 'redis://:p%40ss%3Aw%2Frd%21@redis.example.com:6379/0')
+
+    def test_password_with_slash_is_urlencoded(self):
+        """Slash in password is encoded (quote defaults miss '/', we use safe='')."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        url = build_redis_url_from_config({'HOST': 'h', 'PORT': 6379, 'DATABASE': 0, 'PASSWORD': 'a/b'})
+        self.assertEqual(url, 'redis://:a%2Fb@h:6379/0')
+
+    def test_username_with_special_chars_is_urlencoded(self):
+        """Usernames with reserved URL characters must be percent-encoded."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_from_config
+
+        config = {
+            'HOST': 'redis.example.com',
+            'PORT': 6379,
+            'DATABASE': 0,
+            'USERNAME': 'user@acl',
+            'PASSWORD': 'secret',
+        }
+        url = build_redis_url_from_config(config)
+        self.assertEqual(url, 'redis://user%40acl:secret@redis.example.com:6379/0')
 
 
 class TestBuildRedisUrlOptions(TestCase):
@@ -168,6 +217,13 @@ class TestBuildRedisUrlOptions(TestCase):
 
         config = {'SSL': False}
         options = build_redis_url_options(config)
+        self.assertEqual(options, {})
+
+    def test_ssl_enabled_without_extras(self):
+        """SSL True with no INSECURE_SKIP_TLS_VERIFY or CA_CERT_PATH yields empty options."""
+        from netbox_healthcheck_plugin.backends.redis import build_redis_url_options
+
+        options = build_redis_url_options({'SSL': True})
         self.assertEqual(options, {})
 
     def test_ssl_insecure(self):
@@ -218,6 +274,7 @@ class TestNetBoxRedisCacheHealthCheck(TestCase):
 
         backend = NetBoxRedisCacheHealthCheck()
         self.assertEqual(backend._redis_url, 'redis://cache-redis-host:6379/1')
+        self.assertIsNone(backend._config_error)
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
     def test_repr(self, mock_settings):
@@ -230,25 +287,26 @@ class TestNetBoxRedisCacheHealthCheck(TestCase):
         self.assertEqual(repr(backend), 'redis:caching')
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
-    @patch('redis.Redis.from_url')
-    def test_run_success(self, mock_from_url, mock_settings):
-        """Test successful health check."""
+    def test_run_success(self, mock_settings):
+        """run() returns None and closes the connection on success."""
+        import redis
+
         from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
 
         mock_settings.REDIS = {'caching': {'HOST': 'localhost'}}
         mock_connection = MagicMock()
-        mock_from_url.return_value = mock_connection
 
         backend = NetBoxRedisCacheHealthCheck()
-        # run() returns None on success, raises on failure
-        self.assertIsNone(backend.run())
+        with patch.object(redis.Redis, 'from_url', return_value=mock_connection) as mock_from_url:
+            self.assertIsNone(backend.run())
 
         mock_from_url.assert_called_once()
         mock_connection.ping.assert_called_once()
+        mock_connection.close.assert_called_once()
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
     def test_run_connection_error(self, mock_settings):
-        """Test health check with connection error."""
+        """redis.ConnectionError maps to ServiceUnavailable."""
         import redis
         from health_check.exceptions import ServiceUnavailable
 
@@ -257,11 +315,179 @@ class TestNetBoxRedisCacheHealthCheck(TestCase):
         mock_settings.REDIS = {'caching': {'HOST': 'nonexistent-host'}}
 
         backend = NetBoxRedisCacheHealthCheck()
+        mock_connection = MagicMock()
+        mock_connection.ping.side_effect = redis.ConnectionError('Connection refused')
+        with (
+            patch.object(redis.Redis, 'from_url', return_value=mock_connection),
+            self.assertRaises(ServiceUnavailable),
+        ):
+            backend.run()
+        mock_connection.close.assert_called_once()
 
-        with patch.object(redis.Redis, 'from_url') as mock_from_url:
-            mock_from_url.side_effect = redis.ConnectionError('Connection refused')
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_run_redis_error_not_connection_error(self, mock_settings):
+        """Non-connection redis errors (e.g. DataError) still map to ServiceUnavailable."""
+        import redis
+        from health_check.exceptions import ServiceUnavailable
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'localhost'}}
+        backend = NetBoxRedisCacheHealthCheck()
+        mock_connection = MagicMock()
+        # DataError is a RedisError but NOT a ConnectionError subclass,
+        # so it hits the second except branch.
+        mock_connection.ping.side_effect = redis.DataError('bad command')
+        with (
+            patch.object(redis.Redis, 'from_url', return_value=mock_connection),
+            self.assertRaises(ServiceUnavailable) as ctx,
+        ):
+            backend.run()
+
+        self.assertIn('DataError', str(ctx.exception))
+        mock_connection.close.assert_called_once()
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_run_generic_exception_not_caught(self, mock_settings):
+        """Non-redis errors (e.g. TypeError from bad config) propagate to the framework."""
+        import redis
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'localhost'}}
+        backend = NetBoxRedisCacheHealthCheck()
+        mock_connection = MagicMock()
+        mock_connection.ping.side_effect = TypeError('bad argument')
+        with (
+            patch.object(redis.Redis, 'from_url', return_value=mock_connection),
+            self.assertRaises(TypeError),
+        ):
+            backend.run()
+        mock_connection.close.assert_called_once()
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_run_password_masked_in_error(self, mock_settings):
+        """Error messages include the masked URL, not the raw password."""
+        import redis
+        from health_check.exceptions import ServiceUnavailable
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'h', 'PORT': 6379, 'DATABASE': 0, 'PASSWORD': 'topsecret'}}
+        backend = NetBoxRedisCacheHealthCheck()
+        mock_connection = MagicMock()
+        mock_connection.ping.side_effect = redis.ConnectionError('refused')
+        with (
+            patch.object(redis.Redis, 'from_url', return_value=mock_connection),
+            self.assertRaises(ServiceUnavailable) as ctx,
+        ):
+            backend.run()
+
+        msg = str(ctx.exception)
+        self.assertNotIn('topsecret', msg)
+        self.assertIn(':REDACTED@', msg)
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_run_real_url_scrubbed_from_inner_message(self, mock_settings):
+        """If the underlying exception echoes the real URL back, it gets scrubbed."""
+        import redis
+        from health_check.exceptions import ServiceUnavailable
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'h', 'PORT': 6379, 'DATABASE': 0, 'PASSWORD': 'hunter2'}}
+        backend = NetBoxRedisCacheHealthCheck()
+        mock_connection = MagicMock()
+        mock_connection.ping.side_effect = redis.ConnectionError(f'Error connecting to {backend._redis_url}: refused')
+        with (
+            patch.object(redis.Redis, 'from_url', return_value=mock_connection),
+            self.assertRaises(ServiceUnavailable) as ctx,
+        ):
+            backend.run()
+
+        self.assertNotIn('hunter2', str(ctx.exception))
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_run_no_mask_when_no_auth(self, mock_settings):
+        """URLs without credentials don't get rewritten by the masking logic."""
+        import redis
+        from health_check.exceptions import ServiceUnavailable
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'plain', 'PORT': 6379, 'DATABASE': 0}}
+        backend = NetBoxRedisCacheHealthCheck()
+        mock_connection = MagicMock()
+        mock_connection.ping.side_effect = redis.ConnectionError('refused')
+        with (
+            patch.object(redis.Redis, 'from_url', return_value=mock_connection),
+            self.assertRaises(ServiceUnavailable) as ctx,
+        ):
+            backend.run()
+
+        self.assertIn('redis://plain:6379/0', str(ctx.exception))
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_run_no_mask_when_username_only(self, mock_settings):
+        """Username-only URLs have no colon before @, so the masker leaves them alone."""
+        import redis
+        from health_check.exceptions import ServiceUnavailable
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'h', 'PORT': 6379, 'DATABASE': 0, 'USERNAME': 'ro'}}
+        backend = NetBoxRedisCacheHealthCheck()
+        mock_connection = MagicMock()
+        mock_connection.ping.side_effect = redis.ConnectionError('refused')
+        with (
+            patch.object(redis.Redis, 'from_url', return_value=mock_connection),
+            self.assertRaises(ServiceUnavailable) as ctx,
+        ):
+            backend.run()
+
+        self.assertIn('ro@h:6379/0', str(ctx.exception))
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_run_raises_for_missing_config(self, mock_settings):
+        """run() fails loudly when the key is absent from settings.REDIS."""
+        from health_check.exceptions import ServiceUnavailable
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'tasks': {'HOST': 'localhost'}}  # no 'caching' key
+        backend = NetBoxRedisCacheHealthCheck()
+        self.assertIsNotNone(backend._config_error)
+
+        with self.assertRaises(ServiceUnavailable) as ctx:
+            backend.run()
+        self.assertIn('caching', str(ctx.exception))
+
+    def test_run_raises_when_redis_setting_absent(self):
+        """Entirely missing settings.REDIS is still a hard fail, not a silent default."""
+        from django.conf import settings
+        from health_check.exceptions import ServiceUnavailable
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        with patch.object(settings, 'REDIS', {}, create=True):
+            backend = NetBoxRedisCacheHealthCheck()
+            self.assertIsNotNone(backend._config_error)
             with self.assertRaises(ServiceUnavailable):
                 backend.run()
+
+    @patch('netbox_healthcheck_plugin.backends.redis.settings')
+    def test_run_redis_library_not_installed(self, mock_settings):
+        """Missing redis-py dependency surfaces as ServiceUnavailable."""
+        from health_check.exceptions import ServiceUnavailable
+
+        from netbox_healthcheck_plugin.backends.redis import NetBoxRedisCacheHealthCheck
+
+        mock_settings.REDIS = {'caching': {'HOST': 'localhost'}}
+        backend = NetBoxRedisCacheHealthCheck()
+
+        with patch.dict(sys.modules, {'redis': None}), self.assertRaises(ServiceUnavailable) as ctx:
+            backend.run()
+        self.assertIn('redis library not installed', str(ctx.exception))
 
 
 class TestNetBoxRedisTasksHealthCheck(TestCase):
@@ -299,18 +525,19 @@ class TestNetBoxRedisTasksHealthCheck(TestCase):
         self.assertEqual(repr(backend), 'redis:tasks')
 
     @patch('netbox_healthcheck_plugin.backends.redis.settings')
-    @patch('redis.Redis.from_url')
-    def test_run_success(self, mock_from_url, mock_settings):
-        """Test successful health check."""
+    def test_run_success(self, mock_settings):
+        """run() returns None and closes the connection on success."""
+        import redis
+
         from netbox_healthcheck_plugin.backends.redis import NetBoxRedisTasksHealthCheck
 
         mock_settings.REDIS = {'tasks': {'HOST': 'localhost'}}
         mock_connection = MagicMock()
-        mock_from_url.return_value = mock_connection
 
         backend = NetBoxRedisTasksHealthCheck()
-        # run() returns None on success, raises on failure
-        self.assertIsNone(backend.run())
+        with patch.object(redis.Redis, 'from_url', return_value=mock_connection) as mock_from_url:
+            self.assertIsNone(backend.run())
 
         mock_from_url.assert_called_once()
         mock_connection.ping.assert_called_once()
+        mock_connection.close.assert_called_once()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers=[
 requires-python = ">=3.12.0"
 
 dependencies = [
-    'django-health-check>=3.23.0,<4',
+    'django-health-check>=4.2.2,<5',
     'redis>=4.0',
 ]
 


### PR DESCRIPTION
## Summary

- Merges #20 (URL-encode Redis password — credit @tacerus, cherry-picked to preserve authorship).
- Updates the plugin to `django-health-check>=4.2.2,<5`. v3 is no longer supported.
- Fixes a handful of Redis backend bugs found during a pre-PR review pass.

## django-health-check v4 migration

- Base class moved: `health_check.backends.HealthCheck` → `health_check.base.HealthCheck` (now a dataclass ABC).
- `check_status()` → `run()`. `ServiceUnavailable` is raised directly instead of `self.add_error`.
- Backends are dataclasses with `@dataclasses.dataclass(repr=False)` so the custom `__repr__` survives.
- Dropped the `health_check.cache` sub-app from `django_apps`; `health_check.cache.backends.CacheBackend` in the default `checks` list is now `health_check.Cache`.
- Template renders `results` (list of `HealthCheckResult` with `.check`/`.error`/`.time_taken`) instead of the old `plugins` list.
- Removed the `NetBoxRedisHealthCheck` backwards-compat alias.

## Redis backend fixes

- URL-encode USERNAME (was raw) and pass `safe=''` to `quote()` so `/` in a password isn't silently let through.
- Narrow `except Exception` to `redis.RedisError` — programming errors (TypeError, etc.) now propagate to the framework's handler instead of being misreported as service unavailability.
- `raise … from None` on redis-py exceptions and scrub the real URL from any echoed error text, so the password doesn't leak via `__cause__` (e.g. Django's DEBUG page).
- Fail loudly when `settings.REDIS[<key>]` is missing. The old behavior (warnings.warn + fall back to `localhost:6379`) could produce false-OK health checks against the wrong Redis.
- Close the Redis connection after `ping()` via `contextlib.closing` so fds don't pile up on repeated checks.
- Precompute the password-masked display URL by rebuilding from the config with `PASSWORD='REDACTED'`. The old hand-rolled masker was splitting on `@` and `:`, which mangled username-only URLs like `redis://user@host:6379/0` into `redis:***@host:6379/0`.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] 100% line coverage of `netbox_healthcheck_plugin/backends/redis.py` (verified locally with `coverage run`)
- [ ] Smoke test in a NetBox 4.5+ deployment